### PR TITLE
patchKeyedChildren中的判断条件有误

### DIFF
--- a/src/runtime-core/renderer.ts
+++ b/src/runtime-core/renderer.ts
@@ -258,7 +258,7 @@ function patchKeyedChildren(c1: any[], c2: any[], container) {
     for (i = e2; i >= s2; i--) {
       const nextChild = c2[i];
 
-      if (newIndexToOldIndexMap[i] === -1) {
+      if (newIndexToOldIndexMap[i - s2] === -1) {
         // 说明是个新增的节点
         patch(null, c2[i], container);
       } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,9 +699,9 @@ ansi-escapes@^4.2.1:
     type-fest "^0.11.0"
 
 ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
newIndexToOldIndexMap的下标是从0开始算起的；遍历里面的i是e2的数值，数据对应不上了，应当减去s2的数值，才会从0开始算起。