### PR TITLE
fix:添加对ref重复实例化的判断

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -45,6 +45,11 @@ function convert(value) {
 }
 
 function createRef(value) {
+  // 判断传入的值是否为ref的实例，如果是则表明已经代理过，避免重复代理，直接返回
+  if (isRef(value)) {
+    return value
+  }
+
   const refImpl = new RefImpl(value);
 
   return refImpl;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -22,7 +22,7 @@ importers:
       '@rollup/plugin-commonjs': 13.0.2_rollup@2.79.1
       '@rollup/plugin-node-resolve': 8.4.0_rollup@2.79.1
       '@rollup/plugin-replace': 2.4.2_rollup@2.79.1
-      '@rollup/plugin-typescript': 8.5.0_380b1b2cc54b2b267f5ddaf612a7276c
+      '@rollup/plugin-typescript': 8.5.0_hafrwlgfjmvsm7253l3bfjzhnq
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
       tslib: 2.4.0
@@ -77,29 +77,29 @@ importers:
 
 packages:
 
-  /@pixi/accessibility/6.5.5_83017459f6fa8da3c5eac1b7da2394b7:
+  /@pixi/accessibility/6.5.5_qmaxiwpw7kg2hrpkyg35ui4uw4:
     resolution: {integrity: sha512-mDGDVkNCA1w28zzCT/8x2euxHX55y6ftdDte6FytBwHJHxTzfOKyS6GPqJNrXQB2muu1E/bySqzguiYy1gW/lw==}
     peerDependencies:
       '@pixi/core': 6.5.5
       '@pixi/display': 6.5.5
       '@pixi/utils': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/app/6.5.5_6048224384ec0e9e52cc965de0676294:
+  /@pixi/app/6.5.5_mbeceq4e5qhj4uwmszo6az3csq:
     resolution: {integrity: sha512-VW2kzgj/eNZqGaf+24eL5BGPTHlCDjCYVrKXuFPmPnj48ucUOOKdMQrA8ezmC3LDXsraavwhru8F+JPLUbRtzg==}
     peerDependencies:
       '@pixi/core': 6.5.5
       '@pixi/display': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
     dev: false
 
-  /@pixi/compressed-textures/6.5.5_e594292a804a0a9308d72bda30453418:
+  /@pixi/compressed-textures/6.5.5_4wkcskuajifjgcgxfpndarjuda:
     resolution: {integrity: sha512-e6T1Kg1o9HLVMniSyHcpgtj2VWQV3cdDizIIvdQs7jbrtZCO5ouehViLP2PWm1ZD63hDj6nyVwmZGvkD7FgH1w==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -109,17 +109,17 @@ packages:
       '@pixi/utils': 6.5.5
     dependencies:
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/loaders': 6.5.5_5217ff8d214a58bbfe6654b063e798b1
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/loaders': 6.5.5_kil77djbjjmlx7tgksyghz4ywe
       '@pixi/settings': 6.5.5
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
   /@pixi/constants/6.5.5:
     resolution: {integrity: sha512-tuiN6aeMuQv77UHzGNeJiAUiOrt22dybZYrXAVLOF7mDG+zxT96r7R43DvqrWG3GuNh/VCKE5hQLGQybR21nBA==}
     dev: false
 
-  /@pixi/core/6.5.5_51722c3000186ba6afaabc1009eb867a:
+  /@pixi/core/6.5.5_kfzcymaadbv2nl5kxqiat24gpi:
     resolution: {integrity: sha512-Vdod5c5oByqBuqSQq+j+aiLtAUzFGQblCm9Awmuyjsu7Hygyh8080GeAduS4YuCIHEGz5aP9KS/KP92pM+m4Cg==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -135,12 +135,12 @@ packages:
       '@pixi/math': 6.5.5
       '@pixi/runner': 6.5.5
       '@pixi/settings': 6.5.5
-      '@pixi/ticker': 6.5.5_db62f44c4de19f1c2b503c48b25b4be6
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/ticker': 6.5.5_3nrpitcn4gpryk2qhrelew2l4y
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
       '@types/offscreencanvas': 2019.7.0
     dev: false
 
-  /@pixi/display/6.5.5_e56242ec1c4fc1697502b44d03e14cb3:
+  /@pixi/display/6.5.5_4vref3a4j7aws5icwrgqhykmwm:
     resolution: {integrity: sha512-+WnIR9+vrMc6fgdfOPvmsUIggwdAZvjZ0eX3uEEyS6mjFkZCcC8b0fjfpBaTq8dtWWs+sS7ZZqew9TzAlA9o1w==}
     peerDependencies:
       '@pixi/math': 6.5.5
@@ -149,23 +149,23 @@ packages:
     dependencies:
       '@pixi/math': 6.5.5
       '@pixi/settings': 6.5.5
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
   /@pixi/extensions/6.5.5:
     resolution: {integrity: sha512-b85GH6xzh0SgPejLguCLBhq9zoq6gizW8Zwyb+W1s1Q+B6sP6LtAMeir3ZefiXT3nOakeUGEv7bLp76Aon3lyw==}
     dev: false
 
-  /@pixi/extract/6.5.5_32dbffffdad60f8b2890dc6e9f740542:
+  /@pixi/extract/6.5.5_gln777622yhywkeq3rxj65afii:
     resolution: {integrity: sha512-dlGS4BoMAQeMLv2HyfwvLWn4E5/YPuHF32CsclNWvm0A72y7qQYKBRzpQL3Yzo26uflCwNECbTwhcUXaQ3V2tg==}
     peerDependencies:
       '@pixi/core': 6.5.5
       '@pixi/math': 6.5.5
       '@pixi/utils': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
       '@pixi/math': 6.5.5
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
   /@pixi/filter-alpha/6.5.5_@pixi+core@6.5.5:
@@ -173,16 +173,16 @@ packages:
     peerDependencies:
       '@pixi/core': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
     dev: false
 
-  /@pixi/filter-blur/6.5.5_8a0bad9a7ad9b04c82d927b9c4a48051:
+  /@pixi/filter-blur/6.5.5_rif23gt23gyezawze644jjeake:
     resolution: {integrity: sha512-Xu0593Fu463VBk730x0RxnoVPmYhMV16izjCv8E2VVOFG357yUECHuPsc0L+/LCCjT53wxa3JOzNTJVUJ4HjSg==}
     peerDependencies:
       '@pixi/core': 6.5.5
       '@pixi/settings': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
       '@pixi/settings': 6.5.5
     dev: false
 
@@ -191,16 +191,16 @@ packages:
     peerDependencies:
       '@pixi/core': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
     dev: false
 
-  /@pixi/filter-displacement/6.5.5_3dd418e1141937138dc082da294be05f:
+  /@pixi/filter-displacement/6.5.5_hxkbryiude3rhdoaqlncss7al4:
     resolution: {integrity: sha512-GfmsdZmFFSlcBapUp2ElaIJE1Sy14RdxdqTA7PV72U2RL2gzBSD7rOasBoWynkPv3ILsVMGVleuuRitjPhRBDw==}
     peerDependencies:
       '@pixi/core': 6.5.5
       '@pixi/math': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
       '@pixi/math': 6.5.5
     dev: false
 
@@ -209,7 +209,7 @@ packages:
     peerDependencies:
       '@pixi/core': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
     dev: false
 
   /@pixi/filter-noise/6.5.5_@pixi+core@6.5.5:
@@ -217,10 +217,10 @@ packages:
     peerDependencies:
       '@pixi/core': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
     dev: false
 
-  /@pixi/graphics/6.5.5_b911b6a7fcf7368794e23ac48b524d9a:
+  /@pixi/graphics/6.5.5_xei3nj74643ipfhchlciwusnti:
     resolution: {integrity: sha512-gBhznqpNv5IX7exnq3dgdjGaGfyi9quIFnjMC2pBihSJLc+WokM00rhRxz6IfNknDBQG0vkTXkc0WOPbVlt9Nw==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -231,14 +231,14 @@ packages:
       '@pixi/utils': 6.5.5
     dependencies:
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
       '@pixi/math': 6.5.5
-      '@pixi/sprite': 6.5.5_361673838f0400998271de19ac6c1292
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/sprite': 6.5.5_gylhha4paqajtatr3ym2y3assi
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/interaction/6.5.5_bce52e991d6131da9b5bb058dfdd86d6:
+  /@pixi/interaction/6.5.5_xtss5gi5mey5vg23wbmn7xmg2y:
     resolution: {integrity: sha512-YARy4jeU8EbDQSqtDUguMwQS/wPZjFDAKpuOyraF+DeSN+21+hTRcU3YR4Cq2gqb74uBr5ods4fN9BevyaBjcw==}
     peerDependencies:
       '@pixi/core': 6.5.5
@@ -247,14 +247,14 @@ packages:
       '@pixi/ticker': 6.5.5
       '@pixi/utils': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
       '@pixi/math': 6.5.5
-      '@pixi/ticker': 6.5.5_db62f44c4de19f1c2b503c48b25b4be6
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/ticker': 6.5.5_3nrpitcn4gpryk2qhrelew2l4y
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/loaders/6.5.5_5217ff8d214a58bbfe6654b063e798b1:
+  /@pixi/loaders/6.5.5_kil77djbjjmlx7tgksyghz4ywe:
     resolution: {integrity: sha512-fFvdXYh5ije/pHi4XghF3lF71F/ng/yE2+V3n8w/i7SpYI/CDmwjgfbVNtMJ4LaflJAyPcF8NF7r+eKr/1vDFQ==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -262,15 +262,15 @@ packages:
       '@pixi/utils': 6.5.5
     dependencies:
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
   /@pixi/math/6.5.5:
     resolution: {integrity: sha512-3Y8mfcPjmhIBlcUPTlQXuBBl+cyKWHp2mdXtJg3+E72poO0wTnW175oi38alxSgfKE4jZIDtoUaUoAAuJxmMoA==}
     dev: false
 
-  /@pixi/mesh-extras/6.5.5_c6e939491bd419a25dccc0cc721da935:
+  /@pixi/mesh-extras/6.5.5_y3utssi32qm2exomydghehnjgu:
     resolution: {integrity: sha512-j0shm5Sbn1OvtBDQ56uSc6vYkkRXSVrYr7ywSNY05/0yE3cbLWiuA8ZC7fd5iLbDCxvgl3QaYwtz2ao9V8Sn9A==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -280,13 +280,13 @@ packages:
       '@pixi/utils': 6.5.5
     dependencies:
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
       '@pixi/math': 6.5.5
-      '@pixi/mesh': 6.5.5_361673838f0400998271de19ac6c1292
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/mesh': 6.5.5_gylhha4paqajtatr3ym2y3assi
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/mesh/6.5.5_361673838f0400998271de19ac6c1292:
+  /@pixi/mesh/6.5.5_gylhha4paqajtatr3ym2y3assi:
     resolution: {integrity: sha512-IdI8+jIggDoYSCwdxFQqWekWt5eKvL0kFmrseEIABe3HdHBOuROCz2xTXffqdy9RznsbFSRkmpgiO9fZWibzOg==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -297,14 +297,14 @@ packages:
       '@pixi/utils': 6.5.5
     dependencies:
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
       '@pixi/math': 6.5.5
       '@pixi/settings': 6.5.5
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/mixin-cache-as-bitmap/6.5.5_55a7c796e30476e2f4035b6540c0a510:
+  /@pixi/mixin-cache-as-bitmap/6.5.5_kwt4pfxdar3of5adlnsubqffca:
     resolution: {integrity: sha512-rlHW5IbJV6aUhiQpDDjUBtlR5Fn+LhJjpHWHmeurhFMyMFNFGm6BNLfAIoxUe6VMm6oZOYOB6y3MNcAZeg+fXg==}
     peerDependencies:
       '@pixi/core': 6.5.5
@@ -314,12 +314,12 @@ packages:
       '@pixi/sprite': 6.5.5
       '@pixi/utils': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
       '@pixi/math': 6.5.5
       '@pixi/settings': 6.5.5
-      '@pixi/sprite': 6.5.5_361673838f0400998271de19ac6c1292
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/sprite': 6.5.5_gylhha4paqajtatr3ym2y3assi
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
   /@pixi/mixin-get-child-by-name/6.5.5_@pixi+display@6.5.5:
@@ -327,20 +327,20 @@ packages:
     peerDependencies:
       '@pixi/display': 6.5.5
     dependencies:
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
     dev: false
 
-  /@pixi/mixin-get-global-position/6.5.5_a16df45ef507aa832aff8e377d94e8b9:
+  /@pixi/mixin-get-global-position/6.5.5_ufw7ixxva6vigkx7ry3x3fhixe:
     resolution: {integrity: sha512-8fftShp18r/imrgAcaL441VegywrX1rOX/XaYa5EU2pUXi37WRBmn5q3HKY0K/SV0d+EduzDQsdxzFkNuG82Zw==}
     peerDependencies:
       '@pixi/display': 6.5.5
       '@pixi/math': 6.5.5
     dependencies:
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
       '@pixi/math': 6.5.5
     dev: false
 
-  /@pixi/particle-container/6.5.5_b911b6a7fcf7368794e23ac48b524d9a:
+  /@pixi/particle-container/6.5.5_xei3nj74643ipfhchlciwusnti:
     resolution: {integrity: sha512-2r/YD1ilSML3BGBPeL08IW6wwqy201xRRQuOV+/AIDFOy4CXbGhoA2hEP9AvNr3DDCPApM53BECppjcihPyMEA==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -351,11 +351,11 @@ packages:
       '@pixi/utils': 6.5.5
     dependencies:
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
       '@pixi/math': 6.5.5
-      '@pixi/sprite': 6.5.5_361673838f0400998271de19ac6c1292
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/sprite': 6.5.5_gylhha4paqajtatr3ym2y3assi
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
   /@pixi/polyfill/6.5.5:
@@ -365,7 +365,7 @@ packages:
       promise-polyfill: 8.2.3
     dev: false
 
-  /@pixi/prepare/6.5.5_c5a9dfab51b96451cf72c5f688d19796:
+  /@pixi/prepare/6.5.5_ywu57k2rxfsfdt3syx3irumxsy:
     resolution: {integrity: sha512-IXPjIP8xtGkwOhrAxPcxRPvj9wdeA007QDZcDie1ufHOJhHPvB1ryfT1jtEMSF7xPQ/F8589UVgDM+hY8Ij/Qg==}
     peerDependencies:
       '@pixi/core': 6.5.5
@@ -376,13 +376,13 @@ packages:
       '@pixi/ticker': 6.5.5
       '@pixi/utils': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
-      '@pixi/graphics': 6.5.5_b911b6a7fcf7368794e23ac48b524d9a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
+      '@pixi/graphics': 6.5.5_xei3nj74643ipfhchlciwusnti
       '@pixi/settings': 6.5.5
-      '@pixi/text': 6.5.5_ed329c23ded07c753bd7596a0db229ae
-      '@pixi/ticker': 6.5.5_db62f44c4de19f1c2b503c48b25b4be6
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/text': 6.5.5_5uzjyi662b6hko6xlfva3mrjvy
+      '@pixi/ticker': 6.5.5_3nrpitcn4gpryk2qhrelew2l4y
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
   /@pixi/runner/6.5.5:
@@ -393,19 +393,19 @@ packages:
     resolution: {integrity: sha512-U6xeE9Ri10Rm0Ttjhxc0vc2Qzu2NhB9j/YjvO5NwtW6Adx1SsGz71Pgmebt/FoR4OKU4rtDnRKZOfem7LCFoCA==}
     dev: false
 
-  /@pixi/sprite-animated/6.5.5_d858a1bd06660223ba727ad272ab144b:
+  /@pixi/sprite-animated/6.5.5_3bmkdpigmybchotspljhfkyujm:
     resolution: {integrity: sha512-pvjeOkMrlbvKKO4ZDRKdO97ZKt2LUfLNUCfjU+PyEgJww/6vWeY9IQj89fc2QXGPOYIGrZeT8AuYqPCtJMktHw==}
     peerDependencies:
       '@pixi/core': 6.5.5
       '@pixi/sprite': 6.5.5
       '@pixi/ticker': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/sprite': 6.5.5_361673838f0400998271de19ac6c1292
-      '@pixi/ticker': 6.5.5_db62f44c4de19f1c2b503c48b25b4be6
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/sprite': 6.5.5_gylhha4paqajtatr3ym2y3assi
+      '@pixi/ticker': 6.5.5_3nrpitcn4gpryk2qhrelew2l4y
     dev: false
 
-  /@pixi/sprite-tiling/6.5.5_b911b6a7fcf7368794e23ac48b524d9a:
+  /@pixi/sprite-tiling/6.5.5_xei3nj74643ipfhchlciwusnti:
     resolution: {integrity: sha512-noxIGDvsq5tmINElqjcCnfFofY5CRTWOgLPyL9vI2zk1QhTBW5T/XHENoWFWyuCZgFkEdI1BcO1Yug0q6u+OgQ==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -416,14 +416,14 @@ packages:
       '@pixi/utils': 6.5.5
     dependencies:
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
       '@pixi/math': 6.5.5
-      '@pixi/sprite': 6.5.5_361673838f0400998271de19ac6c1292
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/sprite': 6.5.5_gylhha4paqajtatr3ym2y3assi
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/sprite/6.5.5_361673838f0400998271de19ac6c1292:
+  /@pixi/sprite/6.5.5_gylhha4paqajtatr3ym2y3assi:
     resolution: {integrity: sha512-s8T5D4zoDgj9DWnPGSHoMwJ4uLs9CDp9cgfzTOhwIirqTeoajpywfNFS5RAFAyVCdh4ltSG2oujP8a86eWF0+A==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -434,14 +434,14 @@ packages:
       '@pixi/utils': 6.5.5
     dependencies:
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
       '@pixi/math': 6.5.5
       '@pixi/settings': 6.5.5
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/spritesheet/6.5.5_0c413a8e3f9b639cba961979f81a4b15:
+  /@pixi/spritesheet/6.5.5_bratvdr7tnrzzouwdf47qgslcu:
     resolution: {integrity: sha512-LCfR1iVYSh0pJUM+PDP/FcP45AV6II3zkt8ojtHHcgsDN1qeggbmIEJ/ohvSMLSpKcLHYXv984wu0wp/fB6NdA==}
     peerDependencies:
       '@pixi/core': 6.5.5
@@ -449,13 +449,13 @@ packages:
       '@pixi/math': 6.5.5
       '@pixi/utils': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/loaders': 6.5.5_5217ff8d214a58bbfe6654b063e798b1
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/loaders': 6.5.5_kil77djbjjmlx7tgksyghz4ywe
       '@pixi/math': 6.5.5
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/text-bitmap/6.5.5_1bf8c7f1d8c3a76326276413fd7512b3:
+  /@pixi/text-bitmap/6.5.5_dp4mp4oyyotwgjrhmqj725iswm:
     resolution: {integrity: sha512-nMi7lb3sYAnPPZ9jF/DxmOo0rjh8/Xmc0YYslagvqFJSlowcF+N9HjMOO5WKyP1OBa/gGrpwrLp9FTmdV4T+MQ==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -469,17 +469,17 @@ packages:
       '@pixi/utils': 6.5.5
     dependencies:
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
-      '@pixi/loaders': 6.5.5_5217ff8d214a58bbfe6654b063e798b1
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
+      '@pixi/loaders': 6.5.5_kil77djbjjmlx7tgksyghz4ywe
       '@pixi/math': 6.5.5
-      '@pixi/mesh': 6.5.5_361673838f0400998271de19ac6c1292
+      '@pixi/mesh': 6.5.5_gylhha4paqajtatr3ym2y3assi
       '@pixi/settings': 6.5.5
-      '@pixi/text': 6.5.5_ed329c23ded07c753bd7596a0db229ae
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/text': 6.5.5_5uzjyi662b6hko6xlfva3mrjvy
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/text/6.5.5_ed329c23ded07c753bd7596a0db229ae:
+  /@pixi/text/6.5.5_5uzjyi662b6hko6xlfva3mrjvy:
     resolution: {integrity: sha512-u33ESpNqtZ4IaBiQkq5BT2KeQYcqokfr5VNatYXIMO8jbHktm0Lwqca9pdr+GhS2/DUyyiRfCmNaPHoabjPo6Q==}
     peerDependencies:
       '@pixi/core': 6.5.5
@@ -488,14 +488,14 @@ packages:
       '@pixi/sprite': 6.5.5
       '@pixi/utils': 6.5.5
     dependencies:
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
       '@pixi/math': 6.5.5
       '@pixi/settings': 6.5.5
-      '@pixi/sprite': 6.5.5_361673838f0400998271de19ac6c1292
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/sprite': 6.5.5_gylhha4paqajtatr3ym2y3assi
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
-  /@pixi/ticker/6.5.5_db62f44c4de19f1c2b503c48b25b4be6:
+  /@pixi/ticker/6.5.5_3nrpitcn4gpryk2qhrelew2l4y:
     resolution: {integrity: sha512-S/LALaHQJTldEpFqgAUgi/fc6/XnDUg5k0DXJLfWT2p1hzuo8q009Izpi/wxd4hPZiOlViQtWyrstjMtrQz2AQ==}
     peerDependencies:
       '@pixi/extensions': 6.5.5
@@ -505,7 +505,7 @@ packages:
       '@pixi/settings': 6.5.5
     dev: false
 
-  /@pixi/utils/6.5.5_8c44d115800d748d472031458d4ff5a5:
+  /@pixi/utils/6.5.5_rrcncfmabv2i2rzagfcy2t7vuu:
     resolution: {integrity: sha512-QtcRR+/Y/F49rQ1vVLsc6dMoLLyLTIJxHDSHxYvlGpQWZG+mRvaWYPZZwFgjdCKzzft1RiwkXI2vL4Zxqfg9CQ==}
     peerDependencies:
       '@pixi/constants': 6.5.5
@@ -561,7 +561,7 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-typescript/8.5.0_380b1b2cc54b2b267f5ddaf612a7276c:
+  /@rollup/plugin-typescript/8.5.0_hafrwlgfjmvsm7253l3bfjzhnq:
     resolution: {integrity: sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -889,42 +889,42 @@ packages:
   /pixi.js/6.5.5:
     resolution: {integrity: sha512-SfvUFl0RNnuELbU4IschzWGPSP1yRidEffQlbHnsXY1xvaCE7MG5snQzlufzAyiyiwRID1I5plSKtVjNvZfk9Q==}
     dependencies:
-      '@pixi/accessibility': 6.5.5_83017459f6fa8da3c5eac1b7da2394b7
-      '@pixi/app': 6.5.5_6048224384ec0e9e52cc965de0676294
-      '@pixi/compressed-textures': 6.5.5_e594292a804a0a9308d72bda30453418
+      '@pixi/accessibility': 6.5.5_qmaxiwpw7kg2hrpkyg35ui4uw4
+      '@pixi/app': 6.5.5_mbeceq4e5qhj4uwmszo6az3csq
+      '@pixi/compressed-textures': 6.5.5_4wkcskuajifjgcgxfpndarjuda
       '@pixi/constants': 6.5.5
-      '@pixi/core': 6.5.5_51722c3000186ba6afaabc1009eb867a
-      '@pixi/display': 6.5.5_e56242ec1c4fc1697502b44d03e14cb3
+      '@pixi/core': 6.5.5_kfzcymaadbv2nl5kxqiat24gpi
+      '@pixi/display': 6.5.5_4vref3a4j7aws5icwrgqhykmwm
       '@pixi/extensions': 6.5.5
-      '@pixi/extract': 6.5.5_32dbffffdad60f8b2890dc6e9f740542
+      '@pixi/extract': 6.5.5_gln777622yhywkeq3rxj65afii
       '@pixi/filter-alpha': 6.5.5_@pixi+core@6.5.5
-      '@pixi/filter-blur': 6.5.5_8a0bad9a7ad9b04c82d927b9c4a48051
+      '@pixi/filter-blur': 6.5.5_rif23gt23gyezawze644jjeake
       '@pixi/filter-color-matrix': 6.5.5_@pixi+core@6.5.5
-      '@pixi/filter-displacement': 6.5.5_3dd418e1141937138dc082da294be05f
+      '@pixi/filter-displacement': 6.5.5_hxkbryiude3rhdoaqlncss7al4
       '@pixi/filter-fxaa': 6.5.5_@pixi+core@6.5.5
       '@pixi/filter-noise': 6.5.5_@pixi+core@6.5.5
-      '@pixi/graphics': 6.5.5_b911b6a7fcf7368794e23ac48b524d9a
-      '@pixi/interaction': 6.5.5_bce52e991d6131da9b5bb058dfdd86d6
-      '@pixi/loaders': 6.5.5_5217ff8d214a58bbfe6654b063e798b1
+      '@pixi/graphics': 6.5.5_xei3nj74643ipfhchlciwusnti
+      '@pixi/interaction': 6.5.5_xtss5gi5mey5vg23wbmn7xmg2y
+      '@pixi/loaders': 6.5.5_kil77djbjjmlx7tgksyghz4ywe
       '@pixi/math': 6.5.5
-      '@pixi/mesh': 6.5.5_361673838f0400998271de19ac6c1292
-      '@pixi/mesh-extras': 6.5.5_c6e939491bd419a25dccc0cc721da935
-      '@pixi/mixin-cache-as-bitmap': 6.5.5_55a7c796e30476e2f4035b6540c0a510
+      '@pixi/mesh': 6.5.5_gylhha4paqajtatr3ym2y3assi
+      '@pixi/mesh-extras': 6.5.5_y3utssi32qm2exomydghehnjgu
+      '@pixi/mixin-cache-as-bitmap': 6.5.5_kwt4pfxdar3of5adlnsubqffca
       '@pixi/mixin-get-child-by-name': 6.5.5_@pixi+display@6.5.5
-      '@pixi/mixin-get-global-position': 6.5.5_a16df45ef507aa832aff8e377d94e8b9
-      '@pixi/particle-container': 6.5.5_b911b6a7fcf7368794e23ac48b524d9a
+      '@pixi/mixin-get-global-position': 6.5.5_ufw7ixxva6vigkx7ry3x3fhixe
+      '@pixi/particle-container': 6.5.5_xei3nj74643ipfhchlciwusnti
       '@pixi/polyfill': 6.5.5
-      '@pixi/prepare': 6.5.5_c5a9dfab51b96451cf72c5f688d19796
+      '@pixi/prepare': 6.5.5_ywu57k2rxfsfdt3syx3irumxsy
       '@pixi/runner': 6.5.5
       '@pixi/settings': 6.5.5
-      '@pixi/sprite': 6.5.5_361673838f0400998271de19ac6c1292
-      '@pixi/sprite-animated': 6.5.5_d858a1bd06660223ba727ad272ab144b
-      '@pixi/sprite-tiling': 6.5.5_b911b6a7fcf7368794e23ac48b524d9a
-      '@pixi/spritesheet': 6.5.5_0c413a8e3f9b639cba961979f81a4b15
-      '@pixi/text': 6.5.5_ed329c23ded07c753bd7596a0db229ae
-      '@pixi/text-bitmap': 6.5.5_1bf8c7f1d8c3a76326276413fd7512b3
-      '@pixi/ticker': 6.5.5_db62f44c4de19f1c2b503c48b25b4be6
-      '@pixi/utils': 6.5.5_8c44d115800d748d472031458d4ff5a5
+      '@pixi/sprite': 6.5.5_gylhha4paqajtatr3ym2y3assi
+      '@pixi/sprite-animated': 6.5.5_3bmkdpigmybchotspljhfkyujm
+      '@pixi/sprite-tiling': 6.5.5_xei3nj74643ipfhchlciwusnti
+      '@pixi/spritesheet': 6.5.5_bratvdr7tnrzzouwdf47qgslcu
+      '@pixi/text': 6.5.5_5uzjyi662b6hko6xlfva3mrjvy
+      '@pixi/text-bitmap': 6.5.5_dp4mp4oyyotwgjrhmqj725iswm
+      '@pixi/ticker': 6.5.5_3nrpitcn4gpryk2qhrelew2l4y
+      '@pixi/utils': 6.5.5_rrcncfmabv2i2rzagfcy2t7vuu
     dev: false
 
   /postcss/8.4.17:
@@ -1149,13 +1149,16 @@ packages:
       uuid: registry.npmmirror.com/uuid/8.3.2
     dev: true
 
-  registry.npmmirror.com/@cypress/xvfb/1.2.4:
+  registry.npmmirror.com/@cypress/xvfb/1.2.4_supports-color@8.1.1:
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@cypress/xvfb/-/xvfb-1.2.4.tgz}
+    id: registry.npmmirror.com/@cypress/xvfb/1.2.4
     name: '@cypress/xvfb'
     version: 1.2.4
     dependencies:
-      debug: registry.npmmirror.com/debug/3.2.7
+      debug: registry.npmmirror.com/debug/3.2.7_supports-color@8.1.1
       lodash.once: registry.npmmirror.com/lodash.once/4.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/@esbuild/android-arm/0.15.10:
@@ -1630,6 +1633,8 @@ packages:
       on-headers: registry.npmmirror.com/on-headers/1.0.2
       safe-buffer: registry.npmmirror.com/safe-buffer/5.1.2
       vary: registry.npmmirror.com/vary/1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/concat-map/0.0.1:
@@ -1671,7 +1676,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@cypress/request': registry.npmmirror.com/@cypress/request/2.88.10
-      '@cypress/xvfb': registry.npmmirror.com/@cypress/xvfb/1.2.4
+      '@cypress/xvfb': registry.npmmirror.com/@cypress/xvfb/1.2.4_supports-color@8.1.1
       '@types/node': registry.npmmirror.com/@types/node/14.18.33
       '@types/sinonjs__fake-timers': registry.npmmirror.com/@types/sinonjs__fake-timers/8.1.1
       '@types/sizzle': registry.npmmirror.com/@types/sizzle/2.3.3
@@ -1733,16 +1738,28 @@ packages:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/debug/-/debug-2.6.9.tgz}
     name: debug
     version: 2.6.9
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: registry.npmmirror.com/ms/2.0.0
     dev: true
 
-  registry.npmmirror.com/debug/3.2.7:
+  registry.npmmirror.com/debug/3.2.7_supports-color@8.1.1:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/debug/-/debug-3.2.7.tgz}
+    id: registry.npmmirror.com/debug/3.2.7
     name: debug
     version: 3.2.7
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: registry.npmmirror.com/ms/2.1.2
+      supports-color: registry.npmmirror.com/supports-color/8.1.1
     dev: true
 
   registry.npmmirror.com/debug/4.3.4_supports-color@8.1.1:
@@ -2907,6 +2924,8 @@ packages:
       is-port-reachable: registry.npmmirror.com/is-port-reachable/4.0.0
       serve-handler: registry.npmmirror.com/serve-handler/6.1.5
       update-check: registry.npmmirror.com/update-check/1.5.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   registry.npmmirror.com/shebang-command/2.0.0:


### PR DESCRIPTION
// update before
const a = ref(1)
const b = ref(a)
console.log( a === b )  // false

// update before
const a = ref(1)
const b = ref(a)
console.log( a === b )  // true

添加这个判断不会对用户对源码的学习增添负担，但可以更加真实的还原源码当中的细节处理