### PR TITLE
fix: 修复shallowUnwrapHandlers.set返回值问题

### DIFF
--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -75,7 +75,8 @@ const shallowUnwrapHandlers = {
   set(target, key, value, receiver) {
     const oldValue = target[key];
     if (isRef(oldValue) && !isRef(value)) {
-      return (target[key].value = value);
+      oldValue.value = value;
+      return true;
     } else {
       return Reflect.set(target, key, value, receiver);
     }


### PR DESCRIPTION
参考了mdn关于[Proxy](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set#%E8%BF%94%E5%9B%9E%E5%80%BC)的介绍，handler.set方法的返回值应该为Boolean值。