### PR TITLE
perf: 优化reactivity模块createGetter复用逻辑

### DIFF
--- a/packages/reactivity/src/baseHandlers.ts
+++ b/packages/reactivity/src/baseHandlers.ts
@@ -16,23 +16,14 @@ const shallowReadonlyGet = createGetter(true, true);
 
 function createGetter(isReadonly = false, shallow = false) {
   return function get(target, key, receiver) {
-    const isExistInReactiveMap = () =>
-      key === ReactiveFlags.RAW && receiver === reactiveMap.get(target);
-
-    const isExistInReadonlyMap = () =>
-      key === ReactiveFlags.RAW && receiver === readonlyMap.get(target);
-
-    const isExistInShallowReadonlyMap = () =>
-      key === ReactiveFlags.RAW && receiver === shallowReadonlyMap.get(target);
-
     if (key === ReactiveFlags.IS_REACTIVE) {
       return !isReadonly;
     } else if (key === ReactiveFlags.IS_READONLY) {
       return isReadonly;
     } else if (
-      isExistInReactiveMap() ||
-      isExistInReadonlyMap() ||
-      isExistInShallowReadonlyMap()
+      key === ReactiveFlags.RAW &&
+      receiver ===
+        (isReadonly ? (shallow ? shallowReadonlyMap : readonlyMap) : reactiveMap).get(target)
     ) {
       return target;
     }


### PR DESCRIPTION
根据`isReadonly`和`shallow`尝试复用响应式变量，减少重复判断